### PR TITLE
Updated the Extensions URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 
   "developer": {
     "name": "Kevin BON",
-    "url": "https://github.com/KevinBon"
+    "url": "https://github.com/KevinBon/webextension--bootstrap-responsiveHelper"
   },
 
   "icons": {


### PR DESCRIPTION
Currently in about:addons the URL links to (https://github.com/KevinBon) which is may irritated other users.
I didn't bump the version because of this small change.