### PR TITLE
Add support for bootstrap4 custom breakpoints

### DIFF
--- a/content_scripts/ct.responsiveHelper.js
+++ b/content_scripts/ct.responsiveHelper.js
@@ -4,6 +4,58 @@
   const ATTR_TAG = 'attr-tag';
   const ATTR_VERSION = 'attr-version';
 
+  // Get all bootstrap4 breakpoints from :root style
+  function getBreakpoints4() {
+    const searchStr = '--breakpoint-';
+
+    // Get all computed :root style properties
+    const style = getComputedStyle( document.documentElement );
+
+    // Loop properties and filter breakpoints
+    // Return array of objects, eg: [{ key: 'xl', val: 1200 }]
+    let lastEmpty = false;
+    let bps = [...Array(1000).keys()].reduce( ( bps, i ) => {
+      if ( lastEmpty )  // Bail out if last entry was already empty.
+        return bps;
+
+      const key = style.item( i );
+
+      if ( ! key.length ) { // Bail out if entry is  empty.
+        lastEmpty = true;
+        return bps;
+      }
+
+      if ( ! key.startsWith( searchStr ) ) { // Filter breakpoint properties
+        return bps;
+      }
+
+      return [
+        ...bps,
+        {
+          key: key.replace( searchStr, '' ),
+          val: parseInt( style.getPropertyValue( key ).trim().replace( 'px', '' ) ),
+        }
+      ]
+      }, [] );
+
+      // Sort breakpoints from large to small.
+      bps.sort( ( a, b ) => {
+        if ( a.val > b.val ) {
+          return -1;
+        }
+        if ( a.val < b.val ) {
+          return 1;
+        }
+        return 0;
+      } );
+
+      // Build the breakpoint config objects.
+      return [...bps].map( ( bp, i ) => bps.length === i + 1
+      ? { tag: bp.key, version: '4', cls: 'd-none d-block' }
+      : { tag: bp.key, version: '4', cls: 'd-none d-' + bp.key + '-block' }
+      );
+  }
+
   function removeOldDOM() {
     const oldContainer = document.querySelector(CONTAINER_SELECTOR);
     if (oldContainer) {
@@ -17,11 +69,7 @@
       { tag: 'md', version: '3', cls: 'visible-md-block' },
       { tag: 'sm', version: '3', cls: 'visible-sm-block' },
       { tag: 'xs', version: '3', cls: 'visible-xs-block' },
-      { tag: 'xl', version: '4', cls: 'd-none d-xl-block' },
-      { tag: 'lg', version: '4', cls: 'd-none d-lg-block' },
-      { tag: 'md', version: '4', cls: 'd-none d-md-block' },
-      { tag: 'sm', version: '4', cls: 'd-none d-sm-block' },
-      { tag: 'xs', version: '4', cls: 'd-none d-block' },
+      ...getBreakpoints4(),
     ];
 
     var container = document.createElement('div');
@@ -81,7 +129,7 @@
        }, 66);
     }
   }
-  removeOldDOM(); 
+  removeOldDOM();
   insertDOM();
   sendMessage();
 }());


### PR DESCRIPTION
Hi,
its just a proposal.
I don't need that feature actually. no rush.

Added a function to extract all bs4 breakpoints from from `:root` style properties.

### Why? Usecase

For example a project, that overwrites the `$grid-breakpoints` variable:
```
$grid-breakpoints: (
  xs: 0,
  xssm: 411px,
  sm: 592px,
  md: 782px,
  lg: 992px,
  xl: 1200px
);
```

Results to this `:root` style properties:
![image](https://user-images.githubusercontent.com/25547694/92298513-30f11f80-ef67-11ea-9ffe-feeb8d206715.png)

The custom breakpoint icon will use the default text color:
![image](https://user-images.githubusercontent.com/25547694/92298609-7feb8480-ef68-11ea-9ebc-d91707ddf759.png)


### Disadvantages

Couldn't find a direct way to extract the breakpoint properties. Therefor its done with a loop, which takes time.
For me, it's around 5-8ms per pageload.

May be this feature might be better to opt out on default.
